### PR TITLE
docs: document uv setup for cpu and cuda environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,27 +38,33 @@ We achieve up to **2× greater inference throughput** compared to standard trans
 
 ## 🏃 Environment Setup
 
-To get started, follow these steps to set up your development environment. We recommend using `conda` for dependency management.
+To get started, follow these steps to set up your development environment. We recommend using [`uv`](https://github.com/astral-sh/uv) for dependency management.
 
-1.  **Create and Activate Conda Environment:**
+1.  **Install and Activate a Virtual Environment:**
     ```bash
-    conda create -n mor python=3.12
-    conda activate mor
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    uv venv
+    source .venv/bin/activate
     ```
 
 2.  **Install Required Packages:**
-    First, ensure your `pip` and `setuptools` are up to date. Then, install `torch` and the dependencies listed in [requirements.txt](https://github.com/raymin0223/mixture_of_recursions/tree/main/requirements.txt).
+    Choose the appropriate setup for your hardware and install `torch` followed by the project dependencies.
 
-    **Note:** We specifically used `torch==2.6.0+cu124`, `flash_attn==2.7.4.post1`, and `transformers==4.52.4`. If you encounter issues, consider these exact versions.
+    - **CPU-only development (e.g., macOS or machines without CUDA):**
+      ```bash
+      uv pip install torch --index-url https://download.pytorch.org/whl/cpu
+      uv pip install -r requirements-cpu.txt
+      ```
 
-    ```bash
-    pip install --upgrade pip
-    pip install --upgrade setuptools
-    pip install torch
-    pip install -r requirements.txt
-    # If you experience issues with flash-attn, try:
-    # pip install flash-attn --no-build-isolation
-    ```
+    - **CUDA-enabled server:**
+      ```bash
+      uv pip install torch --index-url https://download.pytorch.org/whl/cu121
+      uv pip install -r requirements.txt
+      # If you experience issues with flash-attn, try:
+      # uv pip install flash-attn --no-build-isolation
+      ```
+
+    **Note:** We specifically used `torch==2.8.0`, `flash_attn==2.8.2`, and `transformers==4.55.2`. If you encounter issues, consider these exact versions.
 
 
 ## 📚 Dataset Download

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,4 +1,4 @@
-# CUDA server packages for training
+# CPU-only packages for training
 torch==2.8.0
 hydra-core==1.3.2
 omegaconf==2.3.0
@@ -7,17 +7,10 @@ tensorboard==2.20.0
 transformers==4.55.2
 datasets==4.0.0
 accelerate==1.10.0
-deepspeed==0.17.4
 peft==0.17.0
 zstandard==0.23.0
 boto3==1.40.10
 smart_open==7.3.0.post1
-bitsandbytes==0.47.0
-flash-attn==2.8.2
-
-# FlashAttention
-# uv pip install flash-attn --no-build-isolation
-
 
 # packages for evaluation
 sacrebleu==2.5.1
@@ -28,8 +21,3 @@ pytablewriter==1.2.1
 rouge_score==0.1.2
 matplotlib==3.10.5
 more_itertools==10.7.0
-
-# LM-evaluation-harness
-# git clone --depth 1 https://github.com/EleutherAI/lm-evaluation-harness
-# cd lm-evaluation-harness
-# uv pip install -e .


### PR DESCRIPTION
## Summary
- document separate uv installs for CPU-only and CUDA-enabled setups
- add CPU-specific requirements file
- label existing requirements as CUDA server dependencies

## Testing
- `uv pip install torch --index-url https://download.pytorch.org/whl/cpu`
- `uv pip install -r requirements-cpu.txt`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ed6991a60832989c8a8997b3e818f