### PR TITLE
Replace fixed GPU scripts with configurable runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,24 @@ bash scripts/pretrain_eval_fewshot.sh {launcher} {wandb_mode} {gpu_indices} {exp
 ```
 
 
+### 👉 Multi-GPU Quick Start
+
+For an end-to-end workflow that prepares local data directories, downloads the FineWeb-Edu dataset, and launches pretraining, use `scripts/run_all.sh`:
+
+```bash
+# 4-GPU example
+bash scripts/run_all.sh accelerate online 4 --model-size smollm-360m
+```
+
+Replace `4` with `2`, `6`, or `8` to match your hardware. You can also provide explicit configuration names instead of `--model-size`:
+
+```bash
+bash scripts/run_all.sh deepspeed offline 8 250720_pretrain_smollm-360m_rec3_middle_cycle_random_lr3e-3.yaml
+```
+
+When `--model-size` is supplied, every pretraining config in `conf/pretrain` containing that size substring is executed sequentially.
+
+
 ## ✅ Pretrained Checkpoints
 
 We share pretrained checkpoints for our 360M parameter Vanilla, Recursive, and MoR models in [Google Drive](https://drive.google.com/drive/folders/1pYKJOu2aBGC-jgoWbfP6T_vqEYtUVxa4?usp=drive_link). Move checkpoints under `./checkpoints` folder.

--- a/scripts/run_all.sh
+++ b/scripts/run_all.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+
+# Orchestrate data download and pretraining on an arbitrary number of GPUs.
+# Usage:
+#   bash scripts/run_all.sh [accelerate|deepspeed] [online|offline] <num_gpus> (--model-size SIZE | <config1> [config2 ...])
+
+launcher_type=""
+run_mode=""
+
+if [[ "$1" == "deepspeed" || "$1" == "accelerate" ]]; then
+  launcher_type="$1"
+  shift
+fi
+
+if [[ "$1" == "online" || "$1" == "offline" ]]; then
+  run_mode="$1"
+  shift
+fi
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 [accelerate|deepspeed] [online|offline] <num_gpus> (--model-size SIZE | <config1> [config2 ...])"
+  exit 1
+fi
+
+num_gpus="$1"
+shift
+
+if ! [[ "$num_gpus" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: <num_gpus> must be a positive integer"
+  exit 1
+fi
+
+declare -a configs=()
+if [[ "$1" == "--model-size" ]]; then
+  shift
+  model_size="$1"
+  shift
+  mapfile -t found_configs < <(ls conf/pretrain/*"${model_size}"*.yaml 2>/dev/null || true)
+  for f in "${found_configs[@]}"; do
+    configs+=("$(basename "$f" .yaml)")
+  done
+else
+  configs=("$@")
+fi
+
+if [ ${#configs[@]} -eq 0 ]; then
+  echo "ERROR: No config names found. Provide --model-size or explicit config names."
+  exit 1
+fi
+
+# Step 0: create data directories if missing
+mkdir -p hf_cache hf_datasets hf_models results
+
+# Step 1: ensure datasets are available
+bash lm_dataset/download_scripts/download_langauge_modeling_datasets.sh
+
+# Step 2: launch training
+GPU_IDS=$(seq -s, 0 $((num_gpus-1)))
+cmd=(bash scripts/pretrain.sh)
+[ -n "$launcher_type" ] && cmd+=("$launcher_type")
+[ -n "$run_mode" ] && cmd+=("$run_mode")
+cmd+=("$GPU_IDS")
+for cfg in "${configs[@]}"; do
+  "${cmd[@]}" "$cfg"
+done


### PR DESCRIPTION
## Summary
- replace per-GPU training scripts with a single `run_all.sh` that accepts any GPU count and optionally filters configs by model size
- document the new configurable workflow in the multi-GPU quick start instructions

## Testing
- `pip install torch --index-url https://download.pytorch.org/whl/cpu`
- `pip install transformers numpy`
- `pip install datasets`
- `pip install smart_open`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f5183dc488329ab71858726e13440